### PR TITLE
Fix for intellisense

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ LaravelIntervals::last365Days();
 
 // Return
 Joaorbrandao\LaravelIntervals\Interval^ {#382
-    -end: Illuminate\Support\Carbon @1571693543^ {#767
+    +end: Illuminate\Support\Carbon @1571693543^ {#767
         date: 2019-10-21 21:32:23.050513 UTC (+00:00)
     }
-    -id: "last365Days"
-    -name: "last_65_days"
-    -start: Illuminate\Support\Carbon @1540157543^ {#768
+    +id: "last365Days"
+    +name: "last_65_days"
+    +start: Illuminate\Support\Carbon @1540157543^ {#768
         date: 2018-10-21 21:32:23.050440 UTC (+00:00)
     } 
 }

--- a/src/Facades/LaravelIntervals.php
+++ b/src/Facades/LaravelIntervals.php
@@ -7,39 +7,39 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * General
- * @method static self all()
- * @method static self enabled()
+ * @method static array all()
+ * @method static array enabled()
  *
  * Days
- * @method static self last365Days()
- * @method static self last30Days()
- * @method static self last15Days()
- * @method static self last7Days()
- * @method static self dayBeforeYesterday()
- * @method static self yesterday()
- * @method static self today()
- * @method static self tomorrow()
- * @method static self dayAfterTomorrow()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last365Days()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last30Days()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last15Days()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last7Days()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval dayBeforeYesterday()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval yesterday()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval today()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval tomorrow()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval dayAfterTomorrow()
  *
  * Weeks
- * @method static self lastWeek()
- * @method static self currentWeek()
- * @method static self nextWeek()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval lastWeek()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval currentWeek()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval nextWeek()
  *
  * Months
- * @method static self last12Months()
- * @method static self last6Months()
- * @method static self last4Months()
- * @method static self last3Months()
- * @method static self lastMonth()
- * @method static self currentMonth()
- * @method static self nextMonth()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last12Months()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last6Months()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last4Months()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval last3Months()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval lastMonth()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval currentMonth()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval nextMonth()
  *
  * Years
- * @method static self lastYear()
- * @method static self currentYear()
- * @method static self firstQuarterOfCurrentYear()
- * @method static self nextYear()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval lastYear()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval currentYear()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval firstQuarterOfCurrentYear()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval nextYear()
  *
  * @see \Joaorbrandao\LaravelIntervals\Repository
  */

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -10,19 +10,19 @@ class Interval implements JsonSerializable
     /**
      * @var \Carbon\Carbon
      */
-    private $end;
+    public $end;
     /**
      * @var string
      */
-    private $id;
+    public $id;
     /**
      * @var string
      */
-    private $name;
+    public $name;
     /**
      * @var \Carbon\Carbon
      */
-    private $start;
+    public $start;
     /**
      * @var bool
      */
@@ -31,17 +31,6 @@ class Interval implements JsonSerializable
     public function __construct($laravelConfig)
     {
         $this->loadAsArray($laravelConfig);
-    }
-
-    /**
-     * Magically access this properties.
-     *
-     * @param $name
-     * @return mixed
-     */
-    public function __get($name)
-    {
-        return $this->$name;
     }
 
     /**

--- a/tests/Unit/IntervalTest.php
+++ b/tests/Unit/IntervalTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Joaorbrandao\LaravelIntervals\Facades\LaravelIntervals;
 use Joaorbrandao\LaravelIntervals\Interval;
 use Joaorbrandao\LaravelIntervals\Tests\TestCase;
+use Carbon\Carbon;
 
 
 class IntervalsTest extends TestCase
@@ -32,13 +33,52 @@ class IntervalsTest extends TestCase
     /**
      * @test
      */
-    public function the_obtained_interval_properties_cannot_be_reset()
+    public function the_obtained_interval_property_end_can_be_changed()
+    {
+        $beforeChange = $this->interval->end;
+        $this->interval->end = Carbon::now()->addHour();
+        $this->assertNotEquals($beforeChange, $this->interval->end);
+    }
+
+    /**
+     * @test
+     */
+    public function the_obtained_interval_property_id_can_be_changed()
+    {
+        $beforeChange = $this->interval->id;
+        $this->interval->id = 'id';
+        $this->assertNotEquals($beforeChange, $this->interval->id);
+    }
+
+    /**
+     * @test
+     */
+    public function the_obtained_interval_property_name_can_be_changed()
+    {
+        $beforeChange = $this->interval->name;
+        $this->interval->name = 'name';
+        $this->assertNotEquals($beforeChange, $this->interval->name);
+    }
+
+    /**
+     * @test
+     */
+    public function the_obtained_interval_property_start_can_be_changed()
+    {
+        $beforeChange = $this->interval->start;
+        $this->interval->start = Carbon::now();
+        $this->assertNotEquals($beforeChange, $this->interval->start);
+    }
+
+    /**
+     * @test
+     */
+    public function the_obtained_interval_property_enabled_can_not_be_changed()
     {
         $this->expectException('Error');
 
-        $this->interval->start = 1;
+        $this->interval->enabled = true;
     }
-
     /**
      * @test
      */


### PR DESCRIPTION
- Fix docblocks to improve ide readability and to its correct return types.
- Remove magic method get and make the start, end, id and name properties public.