### PR TITLE
Development

### DIFF
--- a/src/Facades/LaravelIntervals.php
+++ b/src/Facades/LaravelIntervals.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
  * General
  * @method static array all()
  * @method static array enabled()
+ * @method static \Joaorbrandao\LaravelIntervals\Interval parse($start, $end, $id = 'custom')
  *
  * Days
  * @method static \Joaorbrandao\LaravelIntervals\Interval last365Days()

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -4,6 +4,7 @@
 namespace Joaorbrandao\LaravelIntervals;
 
 use \JsonSerializable;
+use \DateInterval;
 
 class Interval implements JsonSerializable
 {
@@ -11,18 +12,22 @@ class Interval implements JsonSerializable
      * @var \Carbon\Carbon
      */
     public $end;
+
     /**
      * @var string
      */
     public $id;
+
     /**
      * @var string
      */
     public $name;
+
     /**
      * @var \Carbon\Carbon
      */
     public $start;
+
     /**
      * @var bool
      */
@@ -63,6 +68,28 @@ class Interval implements JsonSerializable
     public function contains($time)
     {
         return $this->start->lessThanOrEqualTo($time) && $this->end->greaterThanOrEqualTo($time);
+    }
+
+    /**
+     * Check if the current interval does not contain a given time in between
+     * the start and end times.
+     *
+     * @param $time
+     * @return bool
+     */
+    public function notContains($time)
+    {
+        return !$this->contains($time);
+    }
+
+    /**
+     * Export this interval to a DateInterval format.
+     *
+     * @return bool|DateInterval
+     */
+    public function toDateInterval()
+    {
+        return $this->end->diff($this->start);
     }
 
     /**

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -4,6 +4,7 @@
 namespace Joaorbrandao\LaravelIntervals;
 
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 use Joaorbrandao\LaravelIntervals\Contracts\LaravelIntervalsInterface;
 use Joaorbrandao\LaravelIntervals\Exceptions\ConfigurationNotFoundException;
 
@@ -60,5 +61,24 @@ class Repository implements LaravelIntervalsInterface
         }
 
         return $dateTimeConfig;
+    }
+
+    /**
+     * Parse a given start and end times to an Interval.
+     *
+     * @param $start
+     * @param $end
+     * @param $id
+     * @return Interval
+     */
+    public function parse($start, $end, $id = 'custom')
+    {
+        return new Interval([
+            'id' => $id,
+            'name' => $id !== null ? Str::snake($id) : $id,
+            'start' => $start,
+            'end' => $end,
+            'enabled' => true
+        ]);
     }
 }

--- a/tests/Unit/IntervalTest.php
+++ b/tests/Unit/IntervalTest.php
@@ -85,6 +85,7 @@ class IntervalsTest extends TestCase
     public function an_interval_contains_a_given_time_between_its_start_and_end()
     {
         $this->assertTrue($this->interval->contains(now()->subMonths(6)));
+        $this->assertFalse($this->interval->notContains(now()->subMonths(6)));
     }
 
     /**
@@ -93,6 +94,7 @@ class IntervalsTest extends TestCase
     public function an_interval_does_not_contain_a_given_time_that_is_not_between_its_start_and_end()
     {
         $this->assertFalse($this->interval->contains(now()->addMonth()));
+        $this->assertTrue($this->interval->notContains(now()->addMonth()));
     }
 
     /**
@@ -101,5 +103,13 @@ class IntervalsTest extends TestCase
     public function an_interval_is_automatically_encoded_to_json()
     {
         $this->assertJson($this->interval->toJson());
+    }
+
+    /**
+     * @test
+     */
+    public function an_interval_can_be_exported_to_native_date_interval()
+    {
+        $this->assertInstanceOf(\DateInterval::class, $this->interval->toDateInterval());
     }
 }

--- a/tests/Unit/LaravelIntervalsTest.php
+++ b/tests/Unit/LaravelIntervalsTest.php
@@ -4,6 +4,7 @@ namespace Joaorbrandao\LaravelIntervals\Tests\Unit;
 
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Joaorbrandao\LaravelIntervals\Facades\LaravelIntervals;
 use Joaorbrandao\LaravelIntervals\Interval;
 use Joaorbrandao\LaravelIntervals\Tests\TestCase;
@@ -81,8 +82,40 @@ class LaravelIntervalsTest extends TestCase
     /**
      * @test
      */
-    public function the_result_can_automatically_be_encoded_to_json()
+    public function the_result_can_be_encoded_to_json()
     {
         $this->assertJson(LaravelIntervals::last365Days()->toJson());
+    }
+
+    /**
+     * @test
+     */
+    public function the_result_can_be_exported_to_date_interval()
+    {
+        $this->assertInstanceOf(\DateInterval::class, LaravelIntervals::last365Days()->toDateInterval());
+    }
+
+    /**
+     * @test
+     */
+    public function a_new_custom_start_and_end_can_be_parsed_to_an_interval()
+    {
+        $this->assertInstanceOf(
+            Interval::class,
+            LaravelIntervals::parse('2019-10-27 10:00:00', '2019-10-26 10:00:00')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function a_new_custom_interval_has_a_snake_case_name_when_passing_an_id()
+    {
+        $snakeName = Str::snake('customLaravelInterval');
+
+        $this->assertEquals(
+            $snakeName,
+            LaravelIntervals::parse('2019-10-27 10:00:00', '2019-10-26 10:00:00', 'customLaravelInterval')->name
+        );
     }
 }


### PR DESCRIPTION
- Add notContains method to check if the interval does not contain a given value.
- Export the Interval to a native PHP DateInterval object.
- Add parse method to Facade to programatically create a brand new instance of custom Interval.